### PR TITLE
Fix bug in pressure rate formula

### DIFF
--- a/scripts/07_fig_predictability.R
+++ b/scripts/07_fig_predictability.R
@@ -31,8 +31,8 @@ hsh_first <- hsh |>
       filter(displayName %in% min_100_snaps, week %in% 1:4) |> 
       group_by(nflId) |>
       summarize(n_plays = length(unique(playId)))
-  ) |> 
-  transmute(nflId, first_hsh = (hurries + sacks + sacks) / n_plays)
+  ) |>
+  transmute(nflId, first_hsh = (hurries + sacks + hits) / n_plays)
 
 hsh_last <- hsh |> 
   filter(nflId %in% min_100_snaps_id, week %in% 5:8) |> 
@@ -46,8 +46,8 @@ hsh_last <- hsh |>
       filter(displayName %in% min_100_snaps, week %in% 5:8) |> 
       group_by(nflId) |>
       summarize(n_plays = length(unique(playId)))
-  ) |> 
-  transmute(nflId, last_hsh = (hurries + sacks + sacks) / n_plays)
+  ) |>
+  transmute(nflId, last_hsh = (hurries + sacks + hits) / n_plays)
 
 
 


### PR DESCRIPTION
## Summary
- fix duplicated `sacks` term when computing pressure rate

## Testing
- `Rscript` or `R` was not available so scripts could not be executed

------
https://chatgpt.com/codex/tasks/task_e_6840567eaa948322ba654d42ce8ba481